### PR TITLE
Missing setting spawndir

### DIFF
--- a/addons/deployBike/deployBike.sqf
+++ b/addons/deployBike/deployBike.sqf
@@ -8,6 +8,7 @@ if ("Exile_Item_DuctTape" in (magazines player)) then {
     player removeItem "Exile_Item_DuctTape";
 	
     _spawnPos = player modelToWorld [0,3,0];
+    _spawnDir =  getDir player;
     do_CreateBike = [player, _spawnPos, _spawnDir];
     publicVariableServer "do_CreateBike";
 	


### PR DESCRIPTION
Scripts take errors due to _spawndir not being set before calling server create bike.